### PR TITLE
use fee share protocol from registry instead of reenter it for every pool

### DIFF
--- a/smart-contracts/assembly/__tests__/pool.spec.ts
+++ b/smart-contracts/assembly/__tests__/pool.spec.ts
@@ -48,7 +48,6 @@ beforeAll(() => {
     .add(aTokenAddress) // token a address
     .add(bTokenAddress) // token b address
     .add(0.5) // fee rate
-    .add(0.05) // fee share protocol
     .add(registeryContractAddr); // registery address
 
   mockScCall(new Args().add(user1Address).serialize());
@@ -62,11 +61,11 @@ describe('Scenario 1: Add liquidity, Swap, Remove liquidity', () => {
     const bAmount = u256.fromU64(100);
 
     // get the LP balance of the user
-    const lpBalance = bytesToU64(
+    const lpBalance = bytesToU256(
       getLPBalance(new Args().add(user1Address).serialize()),
     );
 
-    expect(lpBalance).toStrictEqual(0);
+    expect(lpBalance).toStrictEqual(u256.from(0));
 
     print(`Adding liquidity...`);
 
@@ -75,10 +74,11 @@ describe('Scenario 1: Add liquidity, Swap, Remove liquidity', () => {
 
     addLiquidity(new Args().add(aAmount).add(bAmount).serialize());
 
-    const lpBalance2 = bytesToU64(
+    const lpBalance2 = bytesToU256(
       getLPBalance(new Args().add(user1Address).serialize()),
     );
-    expect(lpBalance2).toStrictEqual(100);
+
+    expect(lpBalance2).toStrictEqual(u256.from(100));
   });
 
   test('add liquidity again', () => {
@@ -86,11 +86,11 @@ describe('Scenario 1: Add liquidity, Swap, Remove liquidity', () => {
     const bAmount = u256.fromU64(200);
 
     // get the LP balance of the user
-    const lpBalance = bytesToU64(
+    const lpBalance = bytesToU256(
       getLPBalance(new Args().add(user1Address).serialize()),
     );
 
-    expect(lpBalance).toStrictEqual(100);
+    expect(lpBalance).toStrictEqual(u256.from(100));
 
     print(`Adding liquidity again with 150 and 200...`);
 
@@ -99,11 +99,11 @@ describe('Scenario 1: Add liquidity, Swap, Remove liquidity', () => {
 
     addLiquidity(new Args().add(aAmount).add(bAmount).serialize());
 
-    const lpBalance2 = bytesToU64(
+    const lpBalance2 = bytesToU256(
       getLPBalance(new Args().add(user1Address).serialize()),
     );
 
-    expect(lpBalance2).toStrictEqual(250);
+    expect(lpBalance2).toStrictEqual(u256.from(250));
   });
 
   test('swap tokens', () => {

--- a/smart-contracts/assembly/contracts/pool.ts
+++ b/smart-contracts/assembly/contracts/pool.ts
@@ -515,7 +515,7 @@ export function getLocalReserveB(): StaticArray<u8> {
  * @returns The price of token A in terms of token B, as a u256 represented as a fraction.
  * Returns zero if the b reserve is zero to avoid division by zero error.
  */
-export function getPriceAInB(): StaticArray<u8> {
+export function getPrice(): StaticArray<u8> {
   const reserveA = _getLocalReserveA();
   const reserveB = _getLocalReserveB();
 
@@ -526,26 +526,6 @@ export function getPriceAInB(): StaticArray<u8> {
 
   // priceAInB = reserveB / reserveA
   const price = SafeMath256.div(reserveB, reserveA);
-
-  return u256ToBytes(price);
-}
-
-/**
- * Retrieves the price of Token B in terms of Token A.
- * @returns The price of token B in terms of token A, as a u256 represented as a fraction.
- * Returns zero if the a reserve is zero to avoid division by zero error.
- */
-export function getPriceBInA(): StaticArray<u8> {
-  const reserveA = _getLocalReserveA();
-  const reserveB = _getLocalReserveB();
-
-  // If reserveA is zero return zero
-  if (reserveA == u256.Zero) {
-    return u256ToBytes(u256.Zero);
-  }
-
-  // priceBInA = reserveA / reserveB
-  const price = SafeMath256.div(reserveA, reserveB);
 
   return u256ToBytes(price);
 }

--- a/smart-contracts/assembly/contracts/pool.ts
+++ b/smart-contracts/assembly/contracts/pool.ts
@@ -4,6 +4,7 @@ import {
   Storage,
   Address,
   assertIsSmartContract,
+  print,
 } from '@massalabs/massa-as-sdk';
 import {
   Args,

--- a/smart-contracts/assembly/contracts/pool.ts
+++ b/smart-contracts/assembly/contracts/pool.ts
@@ -79,25 +79,10 @@ export function constructor(binaryArgs: StaticArray<u8>): void {
     .nextString()
     .expect('RegistryAddress is missing or invalid');
 
-  // Esnure that the fee rate is between 0 and 1
-  assert(isBetweenZeroAndOne(inputFeeRate), 'Fee rate must be between 0 and 1');
-
-  // Ensure that the fee share protocol is between 0 and 1
-  assert(
-    isBetweenZeroAndOne(feeShareProtocolInput),
-    'Fee share protocol must be between 0 and 1',
-  );
-
-  /* 
-        To return after tests 
-  // ensure that the aAddress is a valid smart contract address
-  assertIsSmartContract(aAddress);
-
-  // ensure that the bAddress is a valid smart contract address
-  assertIsSmartContract(bAddress);
+  // We already checking if address A, address B, fee rate, and fee share protocol are valid in the registry
 
   // ensure that the registryAddress is a valid smart contract address
-  assertIsSmartContract(registryAddress); */
+  assertIsSmartContract(registryAddress);
 
   // Store fee rate
   Storage.set(feeRate, f64ToBytes(inputFeeRate));

--- a/smart-contracts/assembly/contracts/registry.ts
+++ b/smart-contracts/assembly/contracts/registry.ts
@@ -49,6 +49,22 @@ export function constructor(binaryArgs: StaticArray<u8>): void {
   // If you remove this check, someone could call your constructor function and reset your smart contract.
   assert(Context.isDeployingContract());
 
+  const args = new Args(binaryArgs);
+
+  // read the arguments
+  const feeShareProtocolInput = args
+    .nextF64()
+    .expect('FeeShareProtocol is missing or invalid');
+
+  // ensure that the fee share protocol is between 0 and 1
+  assert(
+    isBetweenZeroAndOne(feeShareProtocolInput),
+    'Fee share protocol must be between 0 and 1',
+  );
+
+  // store fee share protocol
+  Storage.set(feeShareProtocol, f64ToBytes(feeShareProtocolInput));
+
   // set the owner of the registry contract to the caller of the constructor
   _setOwner(Context.caller().toString());
 
@@ -151,10 +167,19 @@ export function getPools(): StaticArray<u8> {
   return new Args().addSerializableObjectArray(retPools).serialize();
 }
 
+/**
+ * Get the fee share protocol
+ * @returns  The fee share protocol
+ */
 export function getFeeShareProtocol(): StaticArray<u8> {
   return Storage.get(feeShareProtocol);
 }
 
+/**
+ * Set the fee share protocol
+ * @param binaryArgs  The fee share protocol (fee)
+ * @returns  void
+ */
 export function setFeeShareProtocol(binaryArgs: StaticArray<u8>): void {
   onlyOwner(); // only owner of registery can set the protocol fee
   const args = new Args(binaryArgs);
@@ -169,10 +194,19 @@ export function setFeeShareProtocol(binaryArgs: StaticArray<u8>): void {
   Storage.set(feeShareProtocol, f64ToBytes(fee));
 }
 
+/**
+ * Get the fee share protocol receiver
+ * @returns  The fee share protocol receiver
+ */
 export function getFeeShareProtocolReceiver(): StaticArray<u8> {
   return Storage.get(feeShareProtocolReceiver);
 }
 
+/**
+ * Set the fee share protocol receiver
+ * @param binaryArgs  The fee share protocol receiver
+ * @returns  void
+ */
 export function setFeeShareProtocolReceiver(binaryArgs: StaticArray<u8>): void {
   onlyOwner(); // only owner of registery can set the protocol fee receiver
 

--- a/smart-contracts/assembly/contracts/token.ts
+++ b/smart-contracts/assembly/contracts/token.ts
@@ -14,7 +14,8 @@ export function constructor(binaryArgs: StaticArray<u8>): void {
   const tokenSymbol = args.nextString().expect('Invalid token symbol');
   const decimals = args.nextU8().expect('Invalid decimals');
   const totalSupply = args.nextU256().expect('Invalid total supply');
-  const url = args.nextString().expect('Invalid url');
+  // optional parameter
+  const url = args.nextString().unwrapOrDefault();
   // optional parameter
   const description = args.nextString().unwrapOrDefault();
 

--- a/smart-contracts/assembly/interfaces/IPool.ts
+++ b/smart-contracts/assembly/interfaces/IPool.ts
@@ -20,21 +20,18 @@ export class IPool {
    * @param {string} aTokenAddress - Address of Token A.
    * @param {string} bTokenAddress - Address of Token B.
    * @param {f64} feeRate - Fee rate for the pool.
-   * @param {f64} feeShareProtocol - Protocol fee share.
    * @param {string} registryAddress - Address of the registry contract.
    */
   init(
     aTokenAddress: string,
     bTokenAddress: string,
     feeRate: f64,
-    feeShareProtocol: f64,
     registryAddress: string,
   ): void {
     const args = new Args()
       .add(aTokenAddress)
       .add(bTokenAddress)
       .add(feeRate)
-      .add(feeShareProtocol)
       .add(registryAddress);
     call(this._origin, 'constructor', args, u64(500000000));
   }

--- a/smart-contracts/assembly/interfaces/IPool.ts
+++ b/smart-contracts/assembly/interfaces/IPool.ts
@@ -1,6 +1,7 @@
 import { Args, bytesToU256, u256ToBytes } from '@massalabs/as-types';
 import { Address, call } from '@massalabs/massa-as-sdk';
 import { u256 } from 'as-bignum/assembly';
+import { feeShareProtocol } from '../contracts/registry';
 
 export class IPool {
   _origin: Address;
@@ -20,21 +21,25 @@ export class IPool {
    * @param {string} aTokenAddress - Address of Token A.
    * @param {string} bTokenAddress - Address of Token B.
    * @param {f64} feeRate - Fee rate for the pool.
+   * @param {f64} feeShareProtocol - Protocol fee share.
    * @param {string} registryAddress - Address of the registry contract.
    */
   init(
     aTokenAddress: string,
     bTokenAddress: string,
     feeRate: f64,
+    feeShareProtocol: f64,
     registryAddress: string,
   ): void {
     const args = new Args()
       .add(aTokenAddress)
       .add(bTokenAddress)
       .add(feeRate)
+      .add(feeShareProtocol)
       .add(registryAddress);
     call(this._origin, 'constructor', args, u64(500000000));
   }
+  
   /**
    * Adds liquidity to the pool.
    *

--- a/smart-contracts/assembly/interfaces/IRegistry.ts
+++ b/smart-contracts/assembly/interfaces/IRegistry.ts
@@ -1,4 +1,9 @@
-import { Args, bytesToString, byteToBool } from '@massalabs/as-types';
+import {
+  Args,
+  bytesToF64,
+  bytesToString,
+  byteToBool,
+} from '@massalabs/as-types';
 import { Address, call } from '@massalabs/massa-as-sdk';
 
 export class IRegistery {
@@ -53,6 +58,16 @@ export class IRegistery {
 
     const deserialized = new Args(result).nextStringArray().unwrap();
     return deserialized;
+  }
+
+  getFeeShareProtocol(): f64 {
+    return bytesToF64(call(this._origin, 'getFeeShareProtocol', new Args(), 0));
+  }
+
+  getFeeShareProtocolReceiver(): string {
+    return bytesToString(
+      call(this._origin, 'getFeeShareProtocolReceiver', new Args(), 0),
+    );
   }
 
   /**

--- a/smart-contracts/assembly/interfaces/IRegistry.ts
+++ b/smart-contracts/assembly/interfaces/IRegistry.ts
@@ -60,10 +60,18 @@ export class IRegistery {
     return deserialized;
   }
 
+  /**
+   * calls the `getPool` function of the registry contract.
+   * @returns {string} The pool address.
+   */
   getFeeShareProtocol(): f64 {
     return bytesToF64(call(this._origin, 'getFeeShareProtocol', new Args(), 0));
   }
 
+  /**
+   *  calls the `getFeeShareProtocolReceiver` function of the registry contract.
+   * @returns {string} The address of the protocol fee receiver.
+   */
   getFeeShareProtocolReceiver(): string {
     return bytesToString(
       call(this._origin, 'getFeeShareProtocolReceiver', new Args(), 0),

--- a/smart-contracts/assembly/lib/liquidityManager.ts
+++ b/smart-contracts/assembly/lib/liquidityManager.ts
@@ -1,4 +1,9 @@
-import { fromBytes, toBytes, u256ToBytes } from '@massalabs/as-types';
+import {
+  bytesToU256,
+  fromBytes,
+  toBytes,
+  u256ToBytes,
+} from '@massalabs/as-types';
 import { Storage, Address } from '@massalabs/massa-as-sdk';
 import { u256 } from 'as-bignum/assembly';
 
@@ -50,7 +55,8 @@ export class LiquidityManager<T> {
       return <T>fromBytes<T>(bytes);
     } else if (idof<T>() == idof<u256>()) {
       // we handle the u256
-      return <T>u256.fromBytes(bytes);
+      // return <T>u256.fromBytes(bytes);
+      return bytesToU256(bytes);
     } else {
       ERROR('Unsupported type for deserialization');
       return <T>0;
@@ -77,7 +83,7 @@ export class LiquidityManager<T> {
       return <T>0;
     } else if (idof<T>() == idof<u256>()) {
       // we handle the u256
-      return <T>new u256(0);
+      return <T>u256.Zero;
     } else {
       ERROR('Unsupported type for zeroValue');
       return <T>0;

--- a/smart-contracts/assembly/lib/liquidityManager.ts
+++ b/smart-contracts/assembly/lib/liquidityManager.ts
@@ -1,0 +1,375 @@
+import { fromBytes, toBytes, u256ToBytes } from '@massalabs/as-types';
+import { Storage, Address } from '@massalabs/massa-as-sdk';
+import { u256 } from 'as-bignum/assembly';
+
+// to move in it's dedicated file
+export class StoragePrefixManager {
+  private prefix: u8 = 0;
+  newPrefix(): u8 {
+    return this.prefix++;
+  }
+}
+
+// Key used to store the total supply in storage.
+const totalSupplyKey: u8 = 0x00;
+
+/**
+ * Manages liquidity for tokens, with generic flexibility.
+ *
+ * @remarks
+ * It does not implement overflow and underflow checks for operations.
+ *
+ * @typeParam T - The type used for liquidity amount.
+ *
+ * @privateRemarks
+ * Balance and allowance are stored separately in storage using distinct prefixes.
+ * Total supply is stored under a fixed key.
+ */
+export class LiquidityManager<T> {
+  private balancePrefix: u8;
+  private allowancePrefix: u8;
+
+  constructor(storagePrefixManager: StoragePrefixManager) {
+    this.balancePrefix = storagePrefixManager.newPrefix();
+    this.allowancePrefix = storagePrefixManager.newPrefix();
+  }
+
+  @inline
+  private _getOrNull(key: StaticArray<u8>): T {
+    if (Storage.has(key)) {
+      let bytes = Storage.get(key);
+      return this.deserialize(bytes);
+    } else {
+      return this.zeroValue();
+    }
+  }
+
+  private deserialize(bytes: StaticArray<u8>): T {
+    if (isInteger<T>()) {
+      //  we handle the basic number type
+      return <T>fromBytes<T>(bytes);
+    } else if (idof<T>() == idof<u256>()) {
+      // we handle the u256
+      return <T>u256.fromBytes(bytes);
+    } else {
+      ERROR('Unsupported type for deserialization');
+      return <T>0;
+    }
+  }
+
+  private serialize(value: T): StaticArray<u8> {
+    if (isInteger<T>()) {
+      //  we handle the basic number type
+      return toBytes(value);
+    } else if (idof<T>() == idof<u256>()) {
+      // we handle the u256
+      //   return (<u256>value).toBytes();
+      return u256ToBytes(<u256>value);
+    } else {
+      ERROR('Unsupported type for serialization');
+      return [];
+    }
+  }
+
+  private zeroValue(): T {
+    if (isInteger<T>()) {
+      //  we handle the basic number type
+      return <T>0;
+    } else if (idof<T>() == idof<u256>()) {
+      // we handle the u256
+      return <T>new u256(0);
+    } else {
+      ERROR('Unsupported type for zeroValue');
+      return <T>0;
+    }
+  }
+
+  @inline
+  private _free(key: StaticArray<u8>): void {
+    const value = this._getOrNull(key);
+    if (Storage.has(key)) {
+      assert(this.isZero(value), `Storage value is not null ${value}`);
+      Storage.del(key);
+    }
+  }
+
+  private isZero(value: T): bool {
+    if (isInteger<T>()) {
+      //  we handle the basic number type
+      return <T>0 == value;
+    } else if (idof<T>() == idof<u256>()) {
+      // we handle the u256
+      return (<u256>value).isZero();
+    } else {
+      ERROR('Unsupported type for isZero');
+      return false;
+    }
+  }
+
+  @inline
+  private _getTotalSupplyKey(): StaticArray<u8> {
+    return [this.balancePrefix, totalSupplyKey];
+  }
+
+  /**
+   * Fetches the total supply of the token.
+   *
+   * @remarks
+   * By default, the total supply is 0.
+   *
+   * @returns The total token supply.
+   */
+  public getTotalSupply(): T {
+    return this._getOrNull(this._getTotalSupplyKey());
+  }
+
+  @inline
+  private _getBalanceStorageKey(user: Address): StaticArray<u8> {
+    const key = new StaticArray<u8>(1);
+    key[0] = this.balancePrefix;
+    return key.concat(user.serialize());
+  }
+
+  private _updateAmount(key: StaticArray<u8>, amount: T, increase: bool): void {
+    var newAmount = this._getOrNull(key);
+    if (increase) {
+      if (idof<T>() == idof<u256>()) {
+        newAmount = u256.add(newAmount, amount) as T;
+      } else {
+        // @ts-ignore arithmetic operations on generic types
+        newAmount += amount;
+      }
+    } else {
+      if (idof<T>() == idof<u256>()) {
+        newAmount = u256.sub(newAmount, amount) as T;
+      } else {
+        // @ts-ignore arithmetic operations on generic types
+        newAmount -= amount;
+      }
+    }
+    Storage.set(key, this.serialize(newAmount));
+  }
+
+  /**
+   * Retrieves the balance for a specified user address.
+   *
+   * @param user - The user's address.
+   *
+   * @returns User's balance, or 0 if no balance is found.
+   */
+  public getBalance(user: Address): T {
+    return this._getOrNull(this._getBalanceStorageKey(user));
+  }
+
+  /**
+   * Eliminates a user's balance from the storage. No action if the balance doesn't exist.
+   *
+   * @param user - The user's address.
+   *
+   * @throws if the user has a non-zero balance.
+   */
+  public removeBalance(user: Address): void {
+    this._free(this._getBalanceStorageKey(user));
+  }
+
+  /**
+   * Transfers an amount of liquidity from one user to another.
+   *
+   * @remarks
+   * If the receiver has no balance in the storage, a new one is created.
+   *
+   * @param from - Sender's address.
+   * @param to - Receiver's address.
+   * @param amount - Amount of liquidity to transfer.
+   *
+   * @throws if the sender's balance is insufficient.
+   */
+  public transfer(from: Address, to: Address, amount: T): void {
+    const fromKey = this._getBalanceStorageKey(from);
+    const fromBalance = this._getOrNull(fromKey);
+    if (idof<T>() == idof<u256>()) {
+      assert(
+        (<u256>fromBalance).greaterThanOrEquals(<u256>amount),
+        'Not enough balance to transfer',
+      );
+    } else {
+      // @ts-ignore arithmetic operations on generic types
+      assert(fromBalance >= amount, 'Not enough balance to transfer');
+    }
+
+    this._updateAmount(fromKey, amount, false);
+
+    const toKey = this._getBalanceStorageKey(to);
+    this._updateAmount(toKey, amount, true);
+  }
+
+  /**
+   * Mints liquidity to a user's balance and updates the total supply.
+   *
+   * @remarks
+   * If the receiver has no balance in the storage, a new one is created.
+   * mint also updates the total supply of the token.
+   *
+   * @param user - The user's address.
+   * @param amount - Amount to mint.
+   */
+  public mint(user: Address, amount: T): void {
+    const userBalance = this._getBalanceStorageKey(user);
+    this._updateAmount(userBalance, amount, true);
+    this._updateAmount(this._getTotalSupplyKey(), amount, true);
+  }
+
+  /**
+   * Burns liquidity from a user's balance and updates the total supply.
+   *
+   * @param user - The user's address.
+   * @param amount - Amount to burn.
+   *
+   * @throws if the user's balance is insufficient.
+   */
+  public burn(user: Address, amount: T): void {
+    const userBalanceKey = this._getBalanceStorageKey(user);
+    if (idof<T>() == idof<u256>()) {
+      assert(
+        <u256>this._getOrNull(userBalanceKey) >= amount,
+        'Not enough balance to burn',
+      );
+    } else {
+      // @ts-ignore arithmetic operations on generic types
+      assert(
+        this._getOrNull(userBalanceKey) >= amount,
+        'Not enough balance to burn',
+      );
+    }
+
+    this._updateAmount(userBalanceKey, amount, false);
+    this._updateAmount(this._getTotalSupplyKey(), amount, false);
+  }
+
+  @inline
+  private _getAllowanceStorageKey(user: Address): StaticArray<u8> {
+    const key = new StaticArray<u8>(1);
+    key[0] = this.allowancePrefix;
+    return key.concat(user.serialize());
+  }
+
+  /**
+   * Fetches the allowed amount a spender can use from an owner's funds.
+   *
+   * @remarks
+   * If the spender has no allowance in the storage, 0 is returned.
+   *
+   * @param owner - Owner's address.
+   * @param spender - Spender's address.
+   * @returns The spender's allowance, or 0 if none is found.
+   */
+  public getAllowance(owner: Address, spender: Address): T {
+    return this._getOrNull(
+      this._getAllowanceStorageKey(owner).concat(spender.serialize()),
+    );
+  }
+
+  /**
+   * Removes the allowance of a spender to use the liquidity of an owner from the storage.
+   *
+   * @remarks
+   * If the spender has no allowance in the storage, the function does nothing.
+   *
+   * @param owner - The address of the owner.
+   * @param spender - The address of the spender.
+   *
+   * @throws if the spender has a non-null allowance.
+   */
+  public removeAllowance(owner: Address, spender: Address): void {
+    this._free(this._getAllowanceStorageKey(owner).concat(spender.serialize()));
+  }
+
+  /**
+   * Updates the allowance set for a spender by an owner.
+   *
+   * @remarks
+   * If the spender has no allowance in the storage, a new allowance is created.
+   *
+   * @param owner - Owner's address.
+   * @param spender - Spender's address.
+   * @param deltaAmount - Amount to adjust the allowance by.
+   * @param increase - Whether to increase (true) or decrease (false) the allowance.
+   *
+   * @throws if attempting to decrease allowance below available amount.
+   */
+  public updateAllowance(
+    owner: Address,
+    spender: Address,
+    deltaAmount: T,
+    increase: bool,
+  ): void {
+    const key = this._getAllowanceStorageKey(owner).concat(spender.serialize());
+    if (!increase) {
+      if (idof<T>() == idof<u256>()) {
+        assert(
+          (<u256>this._getOrNull(key)).greaterThanOrEquals(<u256>deltaAmount),
+          'Not enough allowance to decrease',
+        );
+      } else {
+        // @ts-ignore arithmetic operations on generic types
+        assert(
+          this._getOrNull(key) >= deltaAmount,
+          'Not enough allowance to decrease',
+        );
+      }
+    }
+
+    this._updateAmount(key, deltaAmount, increase);
+  }
+
+  private _useAllowance(owner: Address, spender: Address, amount: T): void {
+    const key = this._getAllowanceStorageKey(owner).concat(spender.serialize());
+    if (idof<T>() == idof<u256>()) {
+      assert(
+        (<u256>this._getOrNull(key)).greaterThanOrEquals(<u256>amount),
+        'Not enough allowance to use',
+      );
+    } else {
+      // @ts-ignore arithmetic operations on generic types
+      assert(this._getOrNull(key) >= amount, 'Not enough allowance to use');
+    }
+
+    this._updateAmount(key, amount, false);
+  }
+
+  /**
+   * Transfers liquidity using the allowance mechanism.
+   *
+   * @param owner - Owner's address.
+   * @param spender - Spender's address.
+   * @param to - Receiver's address.
+   * @param amount - Amount of liquidity to transfer.
+   *
+   * @throws if the spender's allowance is insufficient.
+   */
+  public transferFrom(
+    owner: Address,
+    spender: Address,
+    to: Address,
+    amount: T,
+  ): void {
+    this._useAllowance(owner, spender, amount);
+
+    this.transfer(owner, to, amount);
+  }
+
+  /**
+   * Burns liquidity from an owner using the allowance mechanism.
+   *
+   * @param owner - Owner's address.
+   * @param spender - Spender's address.
+   * @param amount - Amount of liquidity to burn.
+   *
+   * @throws if the spender's allowance is insufficient.
+   */
+  public burnFrom(owner: Address, spender: Address, amount: T): void {
+    this._useAllowance(owner, spender, amount);
+
+    this.burn(owner, amount);
+  }
+}

--- a/smart-contracts/assembly/utils/index.ts
+++ b/smart-contracts/assembly/utils/index.ts
@@ -11,7 +11,7 @@ export function isValidSmartContractAddress(address: string): bool {
 export function _buildPoolKey(
   tokenA: string,
   tokenB: string,
-  feeShareProtocol: f64,
+  inputFeeRate: f64,
 ): string {
   // sort the addresses to ensure that the key of the pool is always the same
   if (tokenA > tokenB) {
@@ -19,6 +19,6 @@ export function _buildPoolKey(
     tokenA = tokenB;
     tokenB = temp;
   }
-  const key = `${tokenA}-${tokenB}-${feeShareProtocol.toString()}`;
+  const key = `${tokenA}-${tokenB}-${inputFeeRate.toString()}`;
   return key;
 }

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "events": "tsx src/events.ts",
         "test": "asp --verbose",
-        "buildnet": "npm run build && tsx src/builnet-tests/test.ts",
+        "buildnet:registry": "npm run build && tsx src/builnet-tests/registry.ts",
         "build": "massa-as-compile",
         "clean": "rimraf build",
         "deploy": "npm run build && tsx src/deploy.ts",

--- a/smart-contracts/src/builnet-tests/registry.ts
+++ b/smart-contracts/src/builnet-tests/registry.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   Args,
+  bytesToF64,
   Mas,
   OperationStatus,
   SmartContract,
@@ -16,7 +17,8 @@ console.log('Deploying contract...');
 
 const byteCode = getScByteCode('build', 'registry.wasm');
 
-const constructorArgs = new Args().serialize();
+// constructr takes fee share protocol as a parameter
+const constructorArgs = new Args().addF64(0.5).serialize();
 
 let contract = await SmartContract.deploy(provider, byteCode, constructorArgs, {
   coins: Mas.fromString('10'),
@@ -28,7 +30,6 @@ async function createNewPool(
   aTokenAddress: string,
   bTokenAddress: string,
   inputFeeRate: number,
-  feeShareProtocol: number,
 ) {
   console.log('Creating new poool.....');
 
@@ -38,7 +39,6 @@ async function createNewPool(
       .addString(aTokenAddress)
       .addString(bTokenAddress)
       .addF64(inputFeeRate)
-      .addF64(feeShareProtocol)
       .serialize(),
     { coins: Mas.fromString('0.1') },
   );
@@ -61,12 +61,24 @@ async function getPools() {
   console.log('Pools:', pools);
 }
 
+async function getRegistryFeeShareProtocol() {
+  const result = await contract.read(
+    'getFeeShareProtocol',
+    new Args().serialize(),
+  );
+
+  const feeShareProtocol = bytesToF64(result.value);
+
+  console.log('Fee share protocol:', feeShareProtocol);
+}
+
 async function test1() {
+  await getRegistryFeeShareProtocol();
+
   await createNewPool(
     'AS1otSzBjxmtAFfqsRViVSEqbW8ARnY5S34B2bYH2qWqTxzJQsiA',
     'AS1otSzBjxmtAFfqsRViVSEqbW8ARnY5S34B2bYH2qWqTxzJQsiA',
     0.5,
-    0.05,
   );
 
   await getPools();

--- a/smart-contracts/src/deployToken.ts
+++ b/smart-contracts/src/deployToken.ts
@@ -17,12 +17,12 @@ console.log('Deploying contract...');
 const byteCode = getScByteCode('build', 'token.wasm');
 
 const constructorArgs = new Args()
-  .addString('BuoyaTest') // token name
-  .addString('BTT') // token symbol
+  .addString('Eagle Finance') // token name
+  .addString('EGL') // token symbol
   .addU8(U8.fromNumber(18)) // token decimals
-  .addU256(U128.fromNumber(180000)) // token total supply
-  .addString('https://www.buoyatest.com') // token url (optional)
-  .addString('fgsdgfsf') // token description (optional)
+  .addU256(U128.fromNumber(1000000000000)) // token total supply
+  .addString('https://eagle.finance/logo.png') // token url (optional)
+  .addString('Dex on Massa') // token description (optional)
   .serialize();
 
 const contract = await SmartContract.deploy(

--- a/smart-contracts/src/deployToken.ts
+++ b/smart-contracts/src/deployToken.ts
@@ -17,11 +17,12 @@ console.log('Deploying contract...');
 const byteCode = getScByteCode('build', 'token.wasm');
 
 const constructorArgs = new Args()
-  .addString('BuoyaTest')
-  .addString('BTT')
-  .addU8(U8.fromNumber(18))
-  .addU256(U128.fromNumber(180000))
-  // .addString('https://www.buoyatest.com') // token url
+  .addString('BuoyaTest') // token name
+  .addString('BTT') // token symbol
+  .addU8(U8.fromNumber(18)) // token decimals
+  .addU256(U128.fromNumber(180000)) // token total supply
+  .addString('https://www.buoyatest.com') // token url (optional)
+  .addString('fgsdgfsf') // token description (optional)
   .serialize();
 
 const contract = await SmartContract.deploy(

--- a/smart-contracts/src/deployToken.ts
+++ b/smart-contracts/src/deployToken.ts
@@ -21,7 +21,7 @@ const constructorArgs = new Args()
   .addString('BTT')
   .addU8(U8.fromNumber(18))
   .addU256(U128.fromNumber(180000))
-  .addString('https://www.buoyatest.com') // token url
+  // .addString('https://www.buoyatest.com') // token url
   .serialize();
 
 const contract = await SmartContract.deploy(


### PR DESCRIPTION
## Pull Request: Improvements to Core Contracts

This pull request implements key improvements to the registry, pool, and token contracts, focusing on enhanced maintainability, precision, and metadata capabilities.

**Key Changes:**

*   **Registry Contract Refactor:**
    *   The protocol fee share mechanism has been refactored to centralize configuration within the Registry contract. This removes the responsibility of managing fee shares from individual Pool contracts and ensures consistency.
    *   New read and write functions for the protocol fee percentage (`getProtocolFeeShare`, `setProtocolFeeShare`) have been introduced. These allow administrators to control the fee collected on transactions.
    *   New read and write functions for the protocol fee recipient address (`getProtocolFeeReceiver`, `setProtocolFeeReceiver`) have been introduced. These allow administrators to configure where fees are directed.

*   **Pool Contract Optimization:**
    *   A new liquidity manager helper has been implemented, providing robust support for `u256` data types. This enhancement ensures more accurate and reliable liquidity management computations.

*   **MRC20 Token Contract Enhancement:**
    *   Optional `imageUrl` and `description` parameters are now available in the MRC20 token contract. This allows for the provision of richer metadata about tokens, improving usability for users and enabling better display in various applications.

